### PR TITLE
ci(stats): log data to logflare

### DIFF
--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -1,18 +1,18 @@
 on:
-    schedule:
-        # https://crontab.guru/once-a-day
-        - cron: 0 0 * * *
-    workflow_dispatch: {}
+  schedule:
+    # https://crontab.guru/once-a-day
+    - cron: 0 0 * * *
+  workflow_dispatch: {}
 
 name: Stats
 jobs:
-    stats:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: gr2m/app-stats-action@v1.x
-              id: stats
-              with:
-                  id: ${{ secrets.ALL_CONTRIBUTORS_APP_ID }}
-                  private_key: ${{ secrets.ALL_CONTRIBUTORS_APP_PRIVATE_KEY }}
-            - run: "echo installations: '${{ steps.stats.outputs.installations }}'"
-            - run: "echo most popular repositories: '${{ steps.stats.outputs.popular_repositories }}'"
+  stats:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: gr2m/app-stats-action@v1.x
+        id: stats
+        with:
+          id: ${{ secrets.ALL_CONTRIBUTORS_APP_ID }}
+          private_key: ${{ secrets.ALL_CONTRIBUTORS_APP_PRIVATE_KEY }}
+      - run: "echo installations: '${{ steps.stats.outputs.installations }}'"
+      - run: "echo most popular repositories: '${{ steps.stats.outputs.popular_repositories }}'"

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -16,3 +16,14 @@ jobs:
           private_key: ${{ secrets.ALL_CONTRIBUTORS_APP_PRIVATE_KEY }}
       - run: "echo installations: '${{ steps.stats.outputs.installations }}'"
       - run: "echo most popular repositories: '${{ steps.stats.outputs.popular_repositories }}'"
+      - uses: logflare/action@v1
+        with:
+          api_key: ${{ secrets.LOGFLARE_API_KEY }}
+          source_id: ${{ secrets.LOGFLARE_SOURCE_ID }}
+          message: "stats: ${{ steps.stats.outputs.installations }} / ${{ steps.stats.outputs.repositories }}"
+          metadata: |
+            {
+              "num_installations": ${{ steps.stats.outputs.installations }},
+              "num_repositories": ${{ steps.stats.outputs.repositories }},
+              "num_suspended_installations": ${{ steps.stats.outputs.suspended_installations }}
+            }


### PR DESCRIPTION
I use the same setup for the WIP app:
https://github.com/wip/app/blob/bd19096682b84a1adea0ca426e7c6bec1fa41ba1/.github/workflows/stats.yml\#L19-L29

This will permit us to add the number of total installations/repositories to a dashboard such as the one form WIP:
https://wip.vercel.app

(for some reason the dashboard is not working right now, here is a screenshot of what it looks like, I want to create something similar for the All Contributors app)

![image](https://user-images.githubusercontent.com/39992/103446463-dcb82c80-4c34-11eb-8dc0-f3eaa8995539.png)
