### PR TITLE
feat: parse github profile URLs

### DIFF
--- a/lib/parse-comment.js
+++ b/lib/parse-comment.js
@@ -150,7 +150,15 @@ function getMatcher(message, action) {
     .data()[0]
     .text.replace(/\s/g, "");
 
-  return whoMatched.startsWith("@") ? whoMatched.substr(1) : whoMatched;
+  if (whoMatched.startsWith("@")) {
+    return whoMatched.substr(1);
+  }
+  const urlMatch = /(https?:\/\/)?github.com\/(.*)/i.exec(whoMatched);
+  if (urlMatch) {
+    return urlMatch[2]
+  }
+
+  return whoMatched
 }
 
 function parseAddComment(message, action) {

--- a/test/unit/parse-comment.test.js
+++ b/test/unit/parse-comment.test.js
@@ -13,6 +13,18 @@ describe("parseComment", () => {
     });
   });
 
+  test("Basic intent to add with github profile url", () => {
+    expect(
+      parseComment(
+        `@all-contributors please add https://github.com/jakeBolam for doc`
+      )
+    ).toEqual({
+      action: "add",
+      who: "jakeBolam",
+      contributions: ["doc"],
+    });
+  });
+
   test("Basic intent to add - ignore case (for action and contributions, NOT for user)", () => {
     expect(
       parseComment(


### PR DESCRIPTION
Great work on all-contributors!

Sometimes, I'm lazy and I paste a URL like `https://github.com/jakeBolam` into a comment - I'd love if all-contributors supported that. This PR adds support.