### PR TITLE
fix: define `research` and `promotion` contribution types

### DIFF
--- a/lib/parse-comment.js
+++ b/lib/parse-comment.js
@@ -35,6 +35,8 @@ const validContributionTypes = [
   "tutorial",
   "usertesting",
   "video",
+  "research",
+  "promotion",
 ];
 
 // Types that are valid multi words, that we need to re map back to their camelCase parts
@@ -91,6 +93,7 @@ const contributionTypeMappings = {
   translations: "translation",
   tutorials: "tutorial",
   videoes: "video",
+  advertisement: "promotion",
 };
 
 // Additional terms to match to types (plurals, aliases etc) that are multi word
@@ -108,6 +111,7 @@ const contributionTypeMultiWordMapping = {
   "user testing": "userTesting",
   "business development": "business",
   "project management": "projectManagement",
+  "social media": "promotion",
 };
 
 const Contributions = {};


### PR DESCRIPTION
- We are adding research and promotion keywords to parse-comment.js 
- for Issue #399

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the [Code of Conduct](https://allcontributors.org/docs/en/project/code-of-conduct) for this project.

Also, please make sure you're familiar with and follow the instructions in the
[contributing guidelines](https://github.com/all-contributors/all-contributors/blob/master/CONTRIBUTING.md) (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?)

e.g. Fixes #399

Check this [list](https://help.github.com/en/articles/closing-issues-using-keywords) of valid keywords.
 -->
**What**: Adding new keywords to parse-comment.js



<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table. <!-- this is optional, see the contributing guidelines for instructions -->
[Bot Usage](https://allcontributors.org/docs/en/bot/installation#4-update-your-contributing-documentation)

<!-- feel free to add additional comments -->
