### PR TITLE
chore: reorder of contribution type mappings

### DIFF
--- a/lib/parse-comment.js
+++ b/lib/parse-comment.js
@@ -50,6 +50,7 @@ const validMultiContributionTypesMapping = {
 // Additional terms to match to types (plurals, aliases etc)
 const contributionTypeMappings = {
   accessibility: "a11y",
+  advertisement: "promotion",
   blogs: "blog",
   blogging: "blog",
   bugs: "bug",
@@ -93,7 +94,6 @@ const contributionTypeMappings = {
   translations: "translation",
   tutorials: "tutorial",
   videos: "video",
-  advertisement: "promotion",
 };
 
 // Additional terms to match to types (plurals, aliases etc) that are multi word

--- a/lib/parse-comment.js
+++ b/lib/parse-comment.js
@@ -25,7 +25,9 @@ const validContributionTypes = [
   "platform",
   "plugin",
   "projectManagement",
+  "promotion",
   "question",
+  "research",
   "review",
   "security",
   "talk",
@@ -35,8 +37,6 @@ const validContributionTypes = [
   "tutorial",
   "usertesting",
   "video",
-  "research",
-  "promotion",
 ];
 
 // Types that are valid multi words, that we need to re map back to their camelCase parts


### PR DESCRIPTION
Fixes the order of keys in the mapping. It's now again alphabetical as it should be 

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table. <!-- this is optional, see the contributing guidelines for instructions -->
[Bot Usage](https://allcontributors.org/docs/en/bot/installation#4-update-your-contributing-documentation)

<!-- feel free to add additional comments -->
