### PR TITLE
fix: support for "event organising" (UK English)

### DIFF
--- a/lib/parse-comment.js
+++ b/lib/parse-comment.js
@@ -103,6 +103,7 @@ const contributionTypeMultiWordMapping = {
   "data collections": "data",
   "data set": "data",
   "data sets": "data",
+  "event organising": "eventOrganizing",
   "event organizing": "eventOrganizing",
   "fund finding": "fundingFinding",
   "funding finding": "fundingFinding",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the [Code of Conduct](https://allcontributors.org/docs/en/project/code-of-conduct) for this project.

Also, please make sure you're familiar with and follow the instructions in the
[contributing guidelines](https://github.com/all-contributors/all-contributors/blob/master/CONTRIBUTING.md) (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?)

e.g. Fixes #0

Check this [list](https://help.github.com/en/articles/closing-issues-using-keywords) of valid keywords.
 -->
**What**: Add support for UK English spelling of `event organising` (US English only supported right now: `event organizing`).

<!-- Why are these changes necessary? -->
**Why**: @aleesteele and I noticed some issues and confusion in trying to add a contributor which was solely the result of only the US english spelling being recognized. See also [the original comments where this took place](https://github.com/alan-turing-institute/the-turing-way/issues/2982?notification_referrer_id=NT_kwDOACz1KLI1NzM3OTAzNzA2OjI5NDYzNDQ#issuecomment-1494387264).

<!-- How were these changes implemented? -->
**How**: By adding a multiword mapping for the UK English

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation - N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table. <!-- this is optional, see the contributing guidelines for instructions -->
[Bot Usage](https://allcontributors.org/docs/en/bot/installation#4-update-your-contributing-documentation)

<!-- feel free to add additional comments -->
Thanks for this fantastic project! I am opening this PR as a suggestion, and appreciate any time you give this. If you feel this does not work for you, feel free to close it - I do not feel offended if so. If this is of any value, I would be very happy to see it merged. 

I am also available to answer any further questions. I have not contributed to this project before so I hope I did my due dilligence sufficiently so, as I also maintain some projects and helicopter contributions can be very strenuous.

Again, thank you for the amazing project 💜 